### PR TITLE
feat(documents): Add functionality for generating signed URLs with GCP

### DIFF
--- a/api/core/urls.py
+++ b/api/core/urls.py
@@ -21,5 +21,5 @@ from django.urls import include, path
 
 urlpatterns = [
     path("aura_ai_admin/", admin.site.urls),
-    path("", include("document_processing.urls")),
+    path("api/", include("versions.urls")),
 ]

--- a/api/document_processing/serializers/__init__.py
+++ b/api/document_processing/serializers/__init__.py
@@ -1,0 +1,3 @@
+from api.document_processing.serializers.generate_signed_url import GenerateSignedUrlSerializer
+
+__all__ = ['GenerateSignedUrlSerializer']

--- a/api/document_processing/serializers/generate_signed_url.py
+++ b/api/document_processing/serializers/generate_signed_url.py
@@ -1,0 +1,5 @@
+from rest_framework import serializers
+
+class GenerateSignedUrlSerializer(serializers.Serializer):
+    file_name = serializers.CharField(max_length=100)
+    content_type = serializers.CharField(max_length=100)

--- a/api/document_processing/services/__init__.py
+++ b/api/document_processing/services/__init__.py
@@ -1,0 +1,3 @@
+from document_processing.services.gcp_cloud_storage import GCPCloudStorageService
+
+__all__ = ["GCPCloudStorageService"]

--- a/api/document_processing/services/gcp_cloud_storage.py
+++ b/api/document_processing/services/gcp_cloud_storage.py
@@ -1,0 +1,66 @@
+import uuid
+from datetime import timedelta
+from google.cloud import storage
+from generals import StorageConstants
+from django.conf import settings
+
+
+class GCPCloudStorageService:
+
+    @staticmethod
+    def generate_uuid_file_name(file_name: str) -> str:
+        random_uuid = uuid.uuid4()
+        return f"{random_uuid}_{file_name}"
+
+    def generate_full_path(self, bucket_path: str, file_name: str) -> tuple[str, str]:
+        """
+        Generates a full file path by combining the provided bucket path with a
+        generated unique file name. Returns the full path and the unique file
+        name as a tuple.
+
+        :param bucket_path: Path to the bucket where the file should be stored.
+        :type bucket_path: str
+        :param file_name: Original name of the file that will be used to generate
+            a unique identifier.
+        :type file_name: str
+        :return: A tuple containing the full path to the file and the unique file
+            name.
+        :rtype: tuple[str, str]
+        """
+        file_name_identifier = self.generate_uuid_file_name(file_name)
+        return (
+            f"{bucket_path}/{file_name_identifier}",
+            file_name_identifier,
+        )
+
+    def generate_signed_url(
+            self,
+            file_name: str,
+            bucket_name: str,
+            bucket_path: str,
+            content_type: str,
+            expiration_minutes: int = StorageConstants.LifeTime.DEFAULT.value,
+    ) -> tuple[str, str]:
+        """
+        Generate a signed URL to upload a file to a GCP bucket.
+
+        :param file_name: Name of the file to be uploaded (includes prefix if necessary).
+        :param bucket_name: Name of the bucket where the file will be uploaded.
+        :param bucket_path: Name of the path in the bucket where the file will be uploaded.
+        :param content_type: Type of the file to be uploaded.
+        :param expiration_minutes: Lifetime of the signed URL in minutes (default is 15 minutes).
+        :return: Signed URL for uploading the file.
+        """
+
+        client = storage.Client(credentials=settings.GS_CREDENTIALS)
+        full_path, file_name_identifier = self.generate_full_path(bucket_path, file_name)
+        bucket = client.bucket(bucket_name)
+        blob = bucket.blob(full_path)
+
+        url = blob.generate_signed_url(
+            version="v4",
+            expiration=timedelta(minutes=expiration_minutes),
+            method="PUT",
+            content_type=content_type,
+        )
+        return url, file_name_identifier

--- a/api/document_processing/urls.py
+++ b/api/document_processing/urls.py
@@ -1,5 +1,6 @@
 from django.urls import include, path
-
+from api.document_processing.views import GenerateSignedUrlView
 
 urlpatterns = [
+    path("generate-signed-url/", GenerateSignedUrlView.as_view(), name="generate-signed-url"),
 ]

--- a/api/document_processing/views/__init__.py
+++ b/api/document_processing/views/__init__.py
@@ -1,0 +1,3 @@
+from api.document_processing.views.upload_file import GenerateSignedUrlView
+
+__all__ = ["GenerateSignedUrlView"]

--- a/api/document_processing/views/upload_file.py
+++ b/api/document_processing/views/upload_file.py
@@ -1,0 +1,67 @@
+from google.api_core.exceptions import GoogleAPIError, NotFound, Forbidden
+from google.auth.exceptions import GoogleAuthError
+from rest_framework import status
+from rest_framework.response import Response
+from document_processing.services import GCPCloudStorageService
+from generals import StorageConstants
+from api.document_processing.serializers import GenerateSignedUrlSerializer
+from rest_framework.views import APIView
+
+
+
+class GenerateSignedUrlView(APIView):
+    serializer_class = GenerateSignedUrlSerializer
+
+    def post(self, request, *args, **kwargs):
+
+        serializer = self.serializer_class(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                {
+                    "error": "Invalid parameters provided.",
+                    "details": serializer.errors
+                },
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        file_name = serializer.data.get("file_name")
+        content_type = serializer.data.get("content_type")
+        bucket_name = str(StorageConstants.Buckets.TEMPORAL.value)
+        bucket_path = str(StorageConstants.Paths.TEMPORAL_DOCUMENT.value)
+        try:
+            signed_url, file_name_identifier = GCPCloudStorageService().generate_signed_url(
+                file_name=file_name,
+                bucket_name=bucket_name,
+                bucket_path=bucket_path,
+                content_type=content_type,
+            )
+            return Response(data={"file_name": file_name_identifier, "url": signed_url}, status=status.HTTP_201_CREATED)
+        except NotFound as e:
+            return Response({
+                "error": f"The specified bucket {bucket_name} was not found.",
+                "details": str(e)
+            }, status=status.HTTP_404_NOT_FOUND)
+
+        except Forbidden as e:
+            return Response({
+                "error": f"Access denied to bucket {bucket_name}. Check your permissions.",
+                "details": str(e)
+            }, status=status.HTTP_403_FORBIDDEN)
+
+        except GoogleAuthError as e:
+            return Response({
+                "error": "There was an authentication error. Check your GCP credentials.",
+                "details": str(e)
+            }, status=status.HTTP_401_UNAUTHORIZED)
+
+        except ValueError as e:
+            return Response({
+                "error": "Invalid parameter provided.",
+                "details": str(e)
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        except GoogleAPIError as e:
+            return Response({
+                "error": "An error occurred with the Google API.",
+                "details": str(e)
+            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/api/generals/constants.py
+++ b/api/generals/constants.py
@@ -18,8 +18,8 @@ class StorageConstants:
         PERMANENT = "aura-core-ai-test", "Permanent Files"
 
     class Paths(TextChoices):
-        TEMPORAL_DOCUMENT = "documents/", "Temporal Document"
-        PERMANENT_DOCUMENT = "accounts/documents/", "Permanent Document"
+        TEMPORAL_DOCUMENT = "documents", "Temporal Document"
+        PERMANENT_DOCUMENT = "accounts/documents", "Permanent Document"
 
     class LifeTime(IntegerChoices):
         DEFAULT = 15, "Default Lifetime (minutes)"

--- a/api/versions/urls/__init__.py
+++ b/api/versions/urls/__init__.py
@@ -1,0 +1,3 @@
+from api.versions.urls.v1 import urlpatterns as v1_urls
+
+urlpatterns = v1_urls

--- a/api/versions/urls/v1.py
+++ b/api/versions/urls/v1.py
@@ -1,0 +1,5 @@
+from django.urls import path, include
+
+urlpatterns = [
+    path("v1/", include("document_processing.urls"))
+]


### PR DESCRIPTION
Introduced a new API endpoint to generate signed URLs for file uploads to GCP Cloud Storage. This includes serializers, views, services, and URL configurations. Updated routing structure and constants to align with the new functionality.